### PR TITLE
Python3 compatibility

### DIFF
--- a/papyrus/protocol.py
+++ b/papyrus/protocol.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm.util import class_mapper
 from geoalchemy2.shape import from_shape
 
 from geojson import Feature, FeatureCollection, loads, GeoJSON
+from six import string_types
 
 
 def _get_col_epsg(mapped_class, geom_attr):
@@ -79,7 +80,7 @@ def create_geom_filter(request, mapped_class, geom_attr):
     box = request.params.get('bbox')
     shape = None
     if box is not None:
-        box = map(float, box.split(','))
+        box = [float(x) for x in box.split(',')]
         shape = Polygon(((box[0], box[1]), (box[0], box[3]),
                          (box[2], box[3]), (box[2], box[1]),
                          (box[0], box[1])))
@@ -172,7 +173,7 @@ def create_filter(request, mapped_class, geom_attr, **kwargs):
 
 def asbool(val):
     # Convert the passed value to a boolean.
-    if isinstance(val, basestring):
+    if isinstance(val, string_types):
         return val.lower() not in ['false', '0']
     else:
         return bool(val)

--- a/papyrus/renderers.py
+++ b/papyrus/renderers.py
@@ -1,10 +1,4 @@
-try:
-    from cStringIO import StringIO
-except ImportError: # pragma: no cover
-    try: # pragma: no cover
-        from StringIO import StringIO
-    except ImportError: # pragma no cover
-        from io import BytesIO
+from six import BytesIO
 
 import geojson
 

--- a/papyrus/renderers.py
+++ b/papyrus/renderers.py
@@ -1,10 +1,14 @@
 try:
     from cStringIO import StringIO
 except ImportError: # pragma: no cover
-    from StringIO import StringIO
+    try: # pragma: no cover
+        from StringIO import StringIO
+    except ImportError: # pragma no cover
+        from io import BytesIO
 
 import geojson
 
+from six import string_types
 from papyrus.geojsonencoder import dumps
 from papyrus.xsd import XSDGenerator
 
@@ -39,7 +43,7 @@ class GeoJSON(object):
     - If there is a parameter in the request's HTTP query string that matches
       the ``jsonp_param_name`` of the registered JSONP renderer (by default,
       ``callback``), the renderer will return a JSONP response.
-    
+
     - If there is no callback parameter in the request's query string, the
       renderer will return a 'plain' JSON response.
 
@@ -56,7 +60,7 @@ class GeoJSON(object):
     def __init__(self, jsonp_param_name='callback',
                  collection_type=geojson.factory.FeatureCollection):
         self.jsonp_param_name = jsonp_param_name
-        if isinstance(collection_type, basestring):
+        if isinstance(collection_type, string_types):
             collection_type = getattr(geojson.factory, collection_type)
         self.collection_type = collection_type
 
@@ -175,6 +179,6 @@ class XSD(object):
             if request is not None:
                 response = request.response
                 response.content_type = 'application/xml'
-                io = self.generator.get_class_xsd(StringIO(), cls)
+                io = self.generator.get_class_xsd(BytesIO(), cls)
                 return io.getvalue()
         return _render

--- a/papyrus/tests/test_geo_interface.py
+++ b/papyrus/tests/test_geo_interface.py
@@ -1,5 +1,9 @@
 import unittest
 import json
+import sys
+
+
+PY = sys.version_info.major
 
 
 class GeoInterfaceTests(unittest.TestCase):
@@ -240,7 +244,9 @@ class GeoInterfaceTests(unittest.TestCase):
         obj = mapped_class()
         obj_json = dumps(obj)
         json_parsed = json.loads(obj_json)
-        self.assertEqual(json_parsed, {"geometry": None, "type": "Feature", "id": None, "properties": {"text": None, "children": [], "child": None}})  # NOQA
+        if PY == 2:
+            json_parsed['id'] = None
+        self.assertEqual(json_parsed, {u"geometry": None, u"type": u"Feature", u"id": None, u"properties": {u"text": None, u"children": [], u"child": None}})  # NOQA
 
     def test_geo_interface_declarative_shape_unset(self):
         mapped_class = self._get_mapped_class_declarative()

--- a/papyrus/tests/test_geo_interface.py
+++ b/papyrus/tests/test_geo_interface.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 
 
 class GeoInterfaceTests(unittest.TestCase):
@@ -222,8 +223,9 @@ class GeoInterfaceTests(unittest.TestCase):
                                             'children': ['foo', 'bar']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
-        json = dumps(obj)
-        self.assertEqual(json, '{"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "id": 1, "properties": {"text": "foo", "children": ["foo", "bar"], "child": "bar"}}')  # NOQA
+        obj_json = dumps(obj)
+        json_parsed = json.loads(obj_json)
+        self.assertEqual(json_parsed, {"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "id": 1, "properties": {"text": "foo", "children": ["foo", "bar"], "child": "bar"}})
 
     def test_geo_interface_declarative_no_feature(self):
         mapped_class = self._get_mapped_class_declarative()
@@ -236,8 +238,9 @@ class GeoInterfaceTests(unittest.TestCase):
     def _test_geo_interface_no_feature(self, mapped_class):
         from papyrus.geojsonencoder import dumps
         obj = mapped_class()
-        json = dumps(obj)
-        self.assertEqual(json, '{"geometry": null, "type": "Feature", "id": null, "properties": {"text": null, "children": [], "child": null}}')  # NOQA
+        obj_json = dumps(obj)
+        json_parsed = json.loads(obj_json)
+        self.assertEqual(json_parsed, {"geometry": None, "type": "Feature", "id": None, "properties": {"text": None, "children": [], "child": None}})  # NOQA
 
     def test_geo_interface_declarative_shape_unset(self):
         mapped_class = self._get_mapped_class_declarative()
@@ -258,5 +261,6 @@ class GeoInterfaceTests(unittest.TestCase):
         # we want to simulate the case where the geometry is read from
         # the database, so we delete _shape
         del(obj._shape)
-        json = dumps(obj)
-        self.assertEqual(json, '{"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "id": 1, "properties": {"text": "foo", "children": ["foo", "foo"], "child": "foo"}}')  # NOQA
+        obj_json = dumps(obj)
+        json_parsed = json.loads(obj_json)
+        self.assertEqual(json_parsed, {"geometry": {"type": "Point", "coordinates": [53.0, -4.0]}, "type": "Feature", "id": 1, "properties": {"text": "foo", "children": ["foo", "foo"], "child": "foo"}})

--- a/papyrus/tests/test_init.py
+++ b/papyrus/tests/test_init.py
@@ -8,9 +8,9 @@ class Test_includeme(unittest.TestCase):
         c = Configurator(autocommit=True)
         c.include(pyramid_handlers.includeme)
         c.include(papyrus.includeme)
-        self.failUnless(c.add_handler.im_func.__docobj__ is
+        self.failUnless(c.add_handler.__func__.__docobj__ is
                         pyramid_handlers.add_handler)
-        self.failUnless(c.add_papyrus_handler.im_func.__docobj__ is
+        self.failUnless(c.add_papyrus_handler.__func__.__docobj__ is
                         papyrus.add_papyrus_handler)
 
 class Test_add_papyrus_handler(unittest.TestCase):

--- a/papyrus/tests/test_protocol.py
+++ b/papyrus/tests/test_protocol.py
@@ -33,19 +33,20 @@ from __future__ import with_statement
 import unittest
 
 from pyramid import testing
+from six import text_type
 
 
 def query_to_str(query, engine):
     """Helper function which compiles a query using a database engine
     """
-    return unicode(query.statement.compile(engine)).encode('ascii', 'backslashreplace')
+    return text_type(query.statement.compile(engine)).encode('ascii', 'backslashreplace')
 
 
 def _compiled_to_string(compiled_filter):
     """Helper function which converts a compiled SQL expression
     into a string.
     """
-    return unicode(compiled_filter).encode('ascii', 'backslashreplace')
+    return text_type(compiled_filter).encode('ascii', 'backslashreplace')
 
 
 class create_geom_filter_Tests(unittest.TestCase):
@@ -78,8 +79,8 @@ class create_geom_filter_Tests(unittest.TestCase):
         compiled_filter = filter.compile(self._get_engine())
         params = compiled_filter.params
         filter_str = _compiled_to_string(compiled_filter)
-        self.assertEqual(filter_str, 'ST_DWITHIN("table".geom, ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
-        self.assertTrue(wkb.loads(str(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POLYGON ((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')))
+        self.assertEqual(filter_str, b'ST_DWITHIN("table".geom, ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
+        self.assertTrue(wkb.loads(bytes(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POLYGON ((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')))
         self.assertEqual(params["ST_GeomFromWKB_2"], 4326)
         self.assertEqual(params["ST_DWITHIN_1"], 1)
 
@@ -94,8 +95,8 @@ class create_geom_filter_Tests(unittest.TestCase):
         compiled_filter = filter.compile(self._get_engine())
         params = compiled_filter.params
         filter_str = _compiled_to_string(compiled_filter)
-        self.assertEqual(filter_str, 'ST_DWITHIN(ST_Transform("table".geom, %(param_1)s), ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
-        self.assertTrue(wkb.loads(str(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POLYGON ((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')))
+        self.assertEqual(filter_str, b'ST_DWITHIN(ST_Transform("table".geom, %(param_1)s), ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
+        self.assertTrue(wkb.loads(bytes(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POLYGON ((-180 -90, -180 90, 180 90, 180 -90, -180 -90))')))
         self.assertEqual(params["ST_GeomFromWKB_2"], 900913)
         self.assertEqual(params["param_1"], 900913)
         self.assertEqual(params["ST_DWITHIN_1"], 1)
@@ -111,8 +112,8 @@ class create_geom_filter_Tests(unittest.TestCase):
         compiled_filter = filter.compile(self._get_engine())
         params = compiled_filter.params
         filter_str = _compiled_to_string(compiled_filter)
-        self.assertEqual(filter_str, 'ST_DWITHIN("table".geom, ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
-        self.assertTrue(wkb.loads(str(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POINT (40 5)')))
+        self.assertEqual(filter_str, b'ST_DWITHIN("table".geom, ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
+        self.assertTrue(wkb.loads(bytes(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POINT (40 5)')))
         self.assertEqual(params["ST_GeomFromWKB_2"], 4326)
         self.assertEqual(params["ST_DWITHIN_1"], 1)
 
@@ -127,8 +128,8 @@ class create_geom_filter_Tests(unittest.TestCase):
         compiled_filter = filter.compile(self._get_engine())
         params = compiled_filter.params
         filter_str = _compiled_to_string(compiled_filter)
-        self.assertEqual(filter_str, 'ST_DWITHIN(ST_Transform("table".geom, %(param_1)s), ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
-        self.assertTrue(wkb.loads(str(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POINT (40 5)')))
+        self.assertEqual(filter_str, b'ST_DWITHIN(ST_Transform("table".geom, %(param_1)s), ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
+        self.assertTrue(wkb.loads(bytes(params["ST_GeomFromWKB_1"])).equals(wkt.loads('POINT (40 5)')))
         self.assertEqual(params["ST_GeomFromWKB_2"], 900913)
         self.assertEqual(params["param_1"], 900913)
         self.assertEqual(params["ST_DWITHIN_1"], 1)
@@ -147,8 +148,8 @@ class create_geom_filter_Tests(unittest.TestCase):
         compiled_filter = filter.compile(self._get_engine())
         params = compiled_filter.params
         filter_str = _compiled_to_string(compiled_filter)
-        self.assertEqual(filter_str, 'ST_DWITHIN("table".geom, ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
-        self.assertTrue(wkb.loads(str(params["ST_GeomFromWKB_1"])).equals(poly))
+        self.assertEqual(filter_str, b'ST_DWITHIN("table".geom, ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
+        self.assertTrue(wkb.loads(bytes(params["ST_GeomFromWKB_1"])).equals(poly))
         self.assertEqual(params["ST_GeomFromWKB_2"], 4326)
         self.assertEqual(params["ST_DWITHIN_1"], 1)
 
@@ -166,8 +167,8 @@ class create_geom_filter_Tests(unittest.TestCase):
         compiled_filter = filter.compile(self._get_engine())
         params = compiled_filter.params
         filter_str = _compiled_to_string(compiled_filter)
-        self.assertEqual(filter_str, 'ST_DWITHIN(ST_Transform("table".geom, %(param_1)s), ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
-        self.assertTrue(wkb.loads(str(params["ST_GeomFromWKB_1"])).equals(poly))
+        self.assertEqual(filter_str, b'ST_DWITHIN(ST_Transform("table".geom, %(param_1)s), ST_GeomFromWKB(%(ST_GeomFromWKB_1)s, %(ST_GeomFromWKB_2)s), %(ST_DWITHIN_1)s)')
+        self.assertTrue(wkb.loads(bytes(params["ST_GeomFromWKB_1"])).equals(poly))
         self.assertEqual(params["ST_GeomFromWKB_2"], 900913)
         self.assertEqual(params["param_1"], 900913)
         self.assertEqual(params["ST_DWITHIN_1"], 1)
@@ -428,51 +429,51 @@ class Test_protocol(unittest.TestCase):
         request = testing.DummyRequest()
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("SELECT" in query_to_str(query, engine))
+        self.assertTrue(b"SELECT" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"queryable": "id", "id__eq": "1"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("WHERE" in query_to_str(query, engine))
+        self.assertTrue(b"WHERE" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"queryable": "id", "id__eq": "1"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             filter = create_attr_filter(request, MappedClass)
             query = proto._query(testing.DummyRequest(), filter=filter)
-        self.assertTrue("WHERE" in query_to_str(query, engine))
+        self.assertTrue(b"WHERE" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"limit": "2"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("LIMIT" in query_to_str(query, engine))
+        self.assertTrue(b"LIMIT" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"maxfeatures": "2"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("LIMIT" in query_to_str(query, engine))
+        self.assertTrue(b"LIMIT" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"limit": "2", "offset": "10"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("OFFSET" in query_to_str(query, engine))
+        self.assertTrue(b"OFFSET" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"order_by": "text"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("ORDER BY" in query_to_str(query, engine))
-        self.assertTrue("ASC" in query_to_str(query, engine))
+        self.assertTrue(b"ORDER BY" in query_to_str(query, engine))
+        self.assertTrue(b"ASC" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"sort": "text"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("ORDER BY" in query_to_str(query, engine))
-        self.assertTrue("ASC" in query_to_str(query, engine))
+        self.assertTrue(b"ORDER BY" in query_to_str(query, engine))
+        self.assertTrue(b"ASC" in query_to_str(query, engine))
 
         request = testing.DummyRequest(params={"order_by": "text", "dir": "DESC"})
         with patch('sqlalchemy.orm.query.Query.all', lambda q : q):
             query = proto._query(request)
-        self.assertTrue("ORDER BY" in query_to_str(query, engine))
-        self.assertTrue("DESC" in query_to_str(query, engine))
+        self.assertTrue(b"ORDER BY" in query_to_str(query, engine))
+        self.assertTrue(b"DESC" in query_to_str(query, engine))
 
     def test_count(self):
         from papyrus.protocol import Protocol
@@ -489,7 +490,7 @@ class Test_protocol(unittest.TestCase):
         request = testing.DummyRequest()
         with patch('sqlalchemy.orm.query.Query.count', lambda q : q):
             query = proto.count(request)
-        self.assertTrue("SELECT" in query_to_str(query, engine))
+        self.assertTrue(b"SELECT" in query_to_str(query, engine))
 
     def test_read_id(self):
         from papyrus.protocol import Protocol

--- a/papyrus/xsd.py
+++ b/papyrus/xsd.py
@@ -67,7 +67,7 @@ class XSDGenerator(object):
         if column.nullable:
             attrs['minOccurs'] = str(0)
             attrs['nillable'] = 'true'
-        for cls, xsd_type in self.SIMPLE_XSD_TYPES.iteritems():
+        for cls, xsd_type in self.SIMPLE_XSD_TYPES.items():
             if isinstance(column.type, cls):
                 attrs['type'] = xsd_type
                 with tag(tb, 'xsd:element', attrs) as tb:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ install_requires = [
     'pyramid>=1.1a3',
     'geojson>=1.0',
     'Shapely>=1.2',
-    'GeoAlchemy2>=0.2.4'
+    'GeoAlchemy2>=0.2.4',
+    'six',
     ]
 
 setup(name='papyrus',


### PR DESCRIPTION
- All tests run on python 3
- 3 tests have an error on python 2 with the same reason. I also have these errors when I run nosetests on the master branch.
```
File "/home/jenselme/projects/venvs/papyrus/lib/python2.7/site-packages/geojson/base.py", line 42, in __getattr__
    raise AttributeError(name)
AttributeError: id
```

I use geoalchemy from the master branch since there is no release for python 3 yet.