### PR TITLE
Use psycopg2-binary package instead of psycopg2

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,6 @@
 nose
 coverage
 WebTest
-psycopg2
+psycopg2-binary
 pyramid_handlers
 flake8

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,7 @@ Running the tests
 Papyrus includes unit tests. Most of the time patches should include new tests.
 
 To run the Papyrus tests, in addition to Papyrus and its dependencies the
-following packages need to be installed: ``nose``, ``mock``, ``psycopg2``,
+following packages need to be installed: ``nose``, ``mock``, ``psycopg2-binary``,
 ``pyramid_handlers``, ``coverage``, and ``WebTest``.
 
 For these packages to install correctly, you have to have header files for


### PR DESCRIPTION
The following warning is displayed when running the unit tests:
```
The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing 
from binary please use "pip install psycopg2-binary" instead.
For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```
