### PR TITLE
Add readonly flag on columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.swp
 papyrus.egg-info/
 dist
+.build
 .coverage
 .tox

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+check: .build/dev_requirements.timestamp
+	.build/venv/bin/flake8 papyrus
+
+tests: .build/dev_requirements.timestamp
+	.build/venv/bin/nosetests
+
+clean:
+	rm -rf .build
+
+.build/venv.timestamp:
+	mkdir -p $(dir $@)
+	python3 -m venv .build/venv
+	touch $@
+
+.build/dev_requirements.timestamp: .build/venv.timestamp dev_requirements.txt
+	.build/venv/bin/pip install -r dev_requirements.txt
+	touch $@

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,14 @@ To run the tests::
 
     $ nosetests
 
+Running the tests using Make
+----------------------------
+
+Make can create a python virtual environment to run the tests for you::
+
+    $ make check
+    $ make tests
+
 Indices and tables
 ==================
 

--- a/papyrus/geo_interface.py
+++ b/papyrus/geo_interface.py
@@ -61,6 +61,21 @@ class GeoInterface(object):
 
     """
 
+    __readonly_properties__ = None
+    """
+    Use this property to protect properties against writing. By default all
+    propeties are writable. Default is ``None``.
+
+    Example::
+
+        class Spot(Base):
+            __tablename__ = 'spots'
+            id = Column(Integer, primary_key=True)
+            geom = Column('the_geom', Geometry('POINT', 4326))
+            name = Column(String(80))
+            __readonly__properties__ = ('name')
+    """
+
     def __init__(self, feature=None):
         """
         Called by the protocol on object creation.
@@ -100,10 +115,16 @@ class GeoInterface(object):
                     self._shape = shape
             elif not col.primary_key:
                 if p.key in feature.properties:
+                    if (self.__readonly_properties__ and
+                            p.key in self.__readonly_properties__):
+                        continue
                     setattr(self, p.key, feature.properties[p.key])
 
         if self.__add_properties__:
                 for k in self.__add_properties__:
+                    if (self.__readonly_properties__ and
+                            p.key in self.__readonly_properties__):
+                        continue
                     setattr(self, k, feature.properties.get(k))
 
     def __read__(self):

--- a/papyrus/protocol.py
+++ b/papyrus/protocol.py
@@ -158,8 +158,7 @@ def create_filter(request, mapped_class, geom_attr, **kwargs):
         mapper. If you use ``declarative_base`` this is the name of
         the geometry attribute as defined in the mapped class.
 
-
-    \**kwargs
+    \\**kwargs
         additional arguments passed to ``create_geom_filter()``.
     """
     attr_filter = create_attr_filter(request, mapped_class)
@@ -202,7 +201,7 @@ class Protocol(object):
           will set 405 (Method Not Allowed) as the response status and
           return right away.
 
-      \**kwargs
+      \\**kwargs
           before_create
             a callback function called before a feature is inserted
             in the database table, the function receives the request,

--- a/papyrus/tests/test_geo_interface.py
+++ b/papyrus/tests/test_geo_interface.py
@@ -34,7 +34,7 @@ class GeoInterfaceTests(unittest.TestCase):
         class Parent(GeoInterface, Base):
             __tablename__ = 'parent'
             id = Column(types.Integer, primary_key=True)
-            name = Column(types.Unicode)
+            name = Column(types.Unicode, info={'readonly': True})
             text = Column(types.Unicode)
             geom = Column(Geometry(geometry_type='GEOMETRY', dimension=2,
                                    srid=3000))
@@ -45,7 +45,6 @@ class GeoInterfaceTests(unittest.TestCase):
             children = association_proxy('children_', 'name')
             child = association_proxy('child_', 'name')
             __add_properties__ = ('child', 'children')
-            __readonly_properties__ = ('name')
 
         return Parent
 
@@ -78,7 +77,7 @@ class GeoInterfaceTests(unittest.TestCase):
         class Parent(Base):
             __tablename__ = 'parent'
             id = Column(types.Integer, primary_key=True)
-            name = Column(types.Unicode)
+            name = Column(types.Unicode, info={'readonly': True})
             text = Column(types.Unicode)
             geom = Column(Geometry(geometry_type='GEOMETRY', dimension=2,
                                    srid=3000))
@@ -89,7 +88,6 @@ class GeoInterfaceTests(unittest.TestCase):
             children = association_proxy('children_', 'name')
             child = association_proxy('child_', 'name')
             __add_properties__ = ('child', 'children')
-            __readonly_properties__ = ('name')
 
         return Parent
 
@@ -117,7 +115,7 @@ class GeoInterfaceTests(unittest.TestCase):
         parent_table = Table(
             'parent', md,
             Column('id', types.Integer, primary_key=True),
-            Column('name', types.Unicode),
+            Column('name', types.Unicode, info={'readonly': True}),
             Column('text', types.Unicode),
             Column('geom', Geometry(geometry_type='GEOMETRY',
                                     dimension=2, srid=3000)),
@@ -140,7 +138,6 @@ class GeoInterfaceTests(unittest.TestCase):
             children = association_proxy('children_', 'name')
             child = association_proxy('child_', 'name')
             __add_properties__ = ('child', 'children')
-            __readonly_properties__ = ('name')
 
         orm.mapper(Parent, parent_table,
                    properties={

--- a/papyrus/tests/test_geo_interface.py
+++ b/papyrus/tests/test_geo_interface.py
@@ -166,14 +166,11 @@ class GeoInterfaceTests(unittest.TestCase):
                                             'children': ['foo', 'foo']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
-        obj.name = 'foo'
-        feature = Feature(id=2, properties={'name': 'bar',
-                                            'text': 'bar', 'child': 'bar',
+        feature = Feature(id=2, properties={'text': 'bar', 'child': 'bar',
                                             'children': ['bar', 'bar']},
                           geometry=Point(coordinates=[55, -5]))
         obj.__update__(feature)
         self.assertEqual(obj.id, 1)
-        self.assertEqual(obj.name, 'foo')
         self.assertEqual(obj.text, 'bar')
         self.assertEqual(obj.child, 'bar')
         self.assertEqual(obj.children, ['bar', 'bar'])
@@ -182,6 +179,33 @@ class GeoInterfaceTests(unittest.TestCase):
         self.assertEqual(point.x, 55)
         self.assertEqual(point.y, -5)
         self.assertEqual(obj.geom.srid, 3000)
+
+    def test_update_readonly_column(self):
+        mapped_class = self._get_mapped_class_declarative()
+        self._test_update_readonly_column(mapped_class)
+
+    def test_update_readonly_column_as_base(self):
+        mapped_class = self._get_mapped_class_declarative_as_base()
+        self._test_update_readonly_column(mapped_class)
+
+    def test_update_readonly_column_non_declarative(self):
+        mapped_class = self._get_mapped_class_non_declarative()
+        self._test_update_readonly_column(mapped_class)
+
+    def _test_update_readonly_column(self, mapped_class):
+        from geojson import Feature, Point
+        from papyrus.geo_interface import OperationNotAllowedError
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'foo',
+                                            'children': ['foo', 'foo']},
+                          geometry=Point(coordinates=[53, -4]))
+        obj = mapped_class(feature)
+        obj.name = 'foo'
+        feature = Feature(id=2, properties={'name': 'bar'})
+        with self.assertRaises(OperationNotAllowedError) as cm:
+            obj.__update__(feature)
+        self.assertEqual(str(cm.exception),
+                         'Column "name" is readonly.')
+        self.assertEqual(obj.name, 'foo')
 
     def test_init_declarative(self):
         mapped_class = self._get_mapped_class_declarative()
@@ -199,8 +223,7 @@ class GeoInterfaceTests(unittest.TestCase):
         from geojson import Feature, Point
         from geoalchemy2.elements import WKBElement
         from geoalchemy2.shape import to_shape
-        feature = Feature(id=1, properties={'name': 'foo',
-                                            'text': 'foo', 'child': 'foo',
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'foo',
                                             'children': ['foo', 'foo']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
@@ -214,6 +237,30 @@ class GeoInterfaceTests(unittest.TestCase):
         self.assertEqual(point.x, 53)
         self.assertEqual(point.y, -4)
         self.assertEqual(obj.geom.srid, 3000)
+
+    def test_init_readonly_column_declarative(self):
+        mapped_class = self._get_mapped_class_declarative()
+        self._test_init_readonly_column(mapped_class)
+
+    def test_init_readonly_column_declarative_as_base(self):
+        mapped_class = self._get_mapped_class_declarative_as_base()
+        self._test_init_readonly_column(mapped_class)
+
+    def test_init_readonly_column_non_declarative(self):
+        mapped_class = self._get_mapped_class_non_declarative()
+        self._test_init_readonly_column(mapped_class)
+
+    def _test_init_readonly_column(self, mapped_class):
+        from geojson import Feature, Point
+        from papyrus.geo_interface import OperationNotAllowedError
+        feature = Feature(id=1, properties={'name': 'foo',
+                                            'text': 'foo', 'child': 'foo',
+                                            'children': ['foo', 'foo']},
+                          geometry=Point(coordinates=[53, -4]))
+        with self.assertRaises(OperationNotAllowedError) as cm:
+            mapped_class(feature)
+        self.assertEqual(str(cm.exception),
+                         'Column "name" is readonly.')
 
     def test_geo_interface_declarative(self):
         mapped_class = self._get_mapped_class_declarative()
@@ -231,8 +278,7 @@ class GeoInterfaceTests(unittest.TestCase):
         from geojson import Feature, Point
         from papyrus.geojsonencoder import dumps
         mapped_class = self._get_mapped_class_declarative()
-        feature = Feature(id=1, properties={'name': 'foo',
-                                            'text': 'foo', 'child': 'bar',
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'bar',
                                             'children': ['foo', 'bar']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)
@@ -267,8 +313,7 @@ class GeoInterfaceTests(unittest.TestCase):
         from geojson import Feature, Point
         from papyrus.geojsonencoder import dumps
         mapped_class = self._get_mapped_class_declarative()
-        feature = Feature(id=1, properties={'name': 'foo',
-                                            'text': 'foo', 'child': 'foo',
+        feature = Feature(id=1, properties={'text': 'foo', 'child': 'foo',
                                             'children': ['foo', 'foo']},
                           geometry=Point(coordinates=[53, -4]))
         obj = mapped_class(feature)

--- a/papyrus/tests/test_protocol.py
+++ b/papyrus/tests/test_protocol.py
@@ -370,6 +370,7 @@ class Test_protocol(unittest.TestCase):
         class MappedClass(Base):
             __tablename__ = "table"
             id = Column(types.Integer, primary_key=True)
+            name = Column(types.Unicode, info={'readonly': True})
             text = Column(types.Unicode)
             geom = Column(Geometry(geometry_type='GEOMETRY',
                                    dimension=2, srid=4326))
@@ -601,6 +602,22 @@ class Test_protocol(unittest.TestCase):
         response = proto.create(request)
         self.assertEqual(response.status_int, 400)
 
+    def test_create_readonly_column(self):
+        from papyrus.protocol import Protocol
+        from pyramid.testing import DummyRequest
+
+        engine = self._get_engine()
+        Session = self._get_session(engine)
+        MappedClass = self._get_mapped_class()
+
+        proto = Protocol(Session, MappedClass, "geom")
+        # we need an actual Request object here, for body to do its job
+        request = DummyRequest({})
+        request.method = 'POST'
+        request.body = '{"type": "Feature", "properties": {"name": "foo"}}'  # NOQA
+        response = proto.create(request)
+        self.assertEqual(response.status_int, 400)
+
     def test_create(self):
         from papyrus.protocol import Protocol
         from pyramid.testing import DummyRequest
@@ -750,6 +767,22 @@ class Test_protocol(unittest.TestCase):
         request.method = 'PUT'
         request.body = '{"type": "Point", "coordinates": [45, 5]}'
         response = proto.update(request, 'a')
+        self.assertEqual(response.status_int, 400)
+
+    def test_update_readonly_column(self):
+        from papyrus.protocol import Protocol
+        from pyramid.testing import DummyRequest
+
+        engine = self._get_engine()
+        Session = self._get_session(engine)
+        MappedClass = self._get_mapped_class()
+
+        proto = Protocol(Session, MappedClass, "geom")
+        # we need an actual Request object here, for body to do its job
+        request = DummyRequest({})
+        request.method = 'POST'
+        request.body = '{"type": "Feature", "properties": {"name": "foo"}}'  # NOQA
+        response = proto.create(request)
         self.assertEqual(response.status_int, 400)
 
     def test_update(self):

--- a/papyrus/tests/test_renderers.py
+++ b/papyrus/tests/test_renderers.py
@@ -384,6 +384,18 @@ class Test_XSD(unittest.TestCase):
         self.assertRaises(UnsupportedColumnTypeError,
                           self._get_elements, (('column', column),))
 
+    def test_readonly(self):
+        from sqlalchemy import Column, types
+        column = Column('_column', types.String(10), info={'readonly': True})
+        elements = self._get_elements((('column', column),))
+        self.assertEqual(len(elements), 1)
+        appinfos = elements[0].findall(
+            self._make_xpath('. annotation appinfo'))
+        self.assertEqual(len(appinfos), 1)
+        readonlys = appinfos[0].findall('readonly')
+        self.assertEqual(len(readonlys), 1)
+        self.assertEqual(readonlys[0].attrib, {'value': 'true'})
+
     def test_sequence_callback(self):
         from sqlalchemy import Column, ForeignKey, types
         from sqlalchemy.orm import relationship


### PR DESCRIPTION
Add the possibility to specify columns as readonly:
```
name = Column(String(80), info={'readonly': True})
```
Create and update requests containing such column will raise an HTTPBadRequest error.

Information is rendered in XSD through annotation/appinfo elements:
```
<xsd:element minOccurs="0" name="name" nillable="true" type="xsd:string">
  <xsd:annotation>
    <xsd:appinfo>
      <readonly value="true"/>
    </xsd:appinfo>
  </xsd:annotation>
</xsd:element>
```